### PR TITLE
Fix a panic when the resource type is not known by the ARM schema

### DIFF
--- a/azlist/azlist.go
+++ b/azlist/azlist.go
@@ -344,7 +344,12 @@ func listDirectChildResource(ctx context.Context, client *Client, schemaTree ARM
 		})
 	}
 
-	for crt, entry := range schemaTree[rt].Children {
+	schemaEntry := schemaTree[rt]
+	if schemaEntry == nil {
+		return result
+	}
+
+	for crt, entry := range schemaEntry.Children {
 		version := entry.Versions[len(entry.Versions)-1]
 		pager := client.resource.NewListChildPager(pid.String(), crt, version)
 		for pager.More() {


### PR DESCRIPTION
Fix a panic when the resource type is not known by the ARM schema. Fix https://github.com/Azure/aztfy/issues/257.