### PR TITLE
arg query -  remove `AuthorizationScopeFilter` 

### DIFF
--- a/azlist/azlist.go
+++ b/azlist/azlist.go
@@ -196,8 +196,6 @@ func ListTrackedResources(ctx context.Context, client *Client, subscriptionId st
 	queryReq := armresourcegraph.QueryRequest{
 		Query: &query,
 		Options: &armresourcegraph.QueryRequestOptions{
-			// TODO: to test with the "alpha" API version
-			// AuthorizationScopeFilter: ptr(armresourcegraph.AuthorizationScopeFilterAtScopeAndBelow),
 			ResultFormat: ptr(armresourcegraph.ResultFormatObjectArray),
 			Top:          ptr(top),
 		},

--- a/azlist/azlist.go
+++ b/azlist/azlist.go
@@ -196,9 +196,10 @@ func ListTrackedResources(ctx context.Context, client *Client, subscriptionId st
 	queryReq := armresourcegraph.QueryRequest{
 		Query: &query,
 		Options: &armresourcegraph.QueryRequestOptions{
-			AuthorizationScopeFilter: ptr(armresourcegraph.AuthorizationScopeFilterAtScopeAndBelow),
-			ResultFormat:             ptr(armresourcegraph.ResultFormatObjectArray),
-			Top:                      ptr(top),
+			// TODO: to test with the "alpha" API version
+			// AuthorizationScopeFilter: ptr(armresourcegraph.AuthorizationScopeFilterAtScopeAndBelow),
+			ResultFormat: ptr(armresourcegraph.ResultFormatObjectArray),
+			Top:          ptr(top),
 		},
 		Subscriptions: []*string{&subscriptionId},
 	}


### PR DESCRIPTION
reference:  https://learn.microsoft.com/en-us/azure/governance/resource-graph/concepts/query-language
 
Just remove it, since we are only using `Resources` table, the `AuthorizationScopeFilter` only works for `PolicyResources` and `AuthorizationResources` tables.